### PR TITLE
fix: enhance layout responsiveness and adjust component styles

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="en">
-			<body className={inter.className}>
+			<body className={`${inter.className} w-scren min-h-screen`}>
 				<ThemeProvider
 					attribute="class"
 					defaultTheme="system"
@@ -29,7 +29,7 @@ export default function RootLayout({
 					<>
 						<header>
 							<nav>
-								<ul className="flex items-center justify-around p-2">
+								<ul className="w-full flex items-center justify-around p-2">
 									<li>
 										<Link href={"/"}>
 											<h1>Melody Mystery</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,17 +14,17 @@ export default function Home() {
 		<main
 			className="
 				grid md:grid-cols-2 
-				p-24 sm:p-2 gap-8
+				p-4 md:p-24 gap-8
 				h-full
 				justify-items-center
 			"
 		>
-			<div className="flex flex-col gap-8 md:justify-self-end">
+			<div className="flex flex-col gap-8 md:justify-self-end w-full">
 				<ErrorMessages />
 				<NbRoundInput />
 				<PlaylistInput />
 			</div>
-			<div className="flex flex-col gap-8 md:justify-self-start">
+			<div className="flex flex-col gap-8 md:justify-self-start w-full">
 				<PlaylistHistory />
 				<PlaylistPresets />
 			</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,6 @@ export default function Home() {
 			</div>
       
 			<div className="flex flex-col gap-8 md:justify-self-start w-full">
-				<PlaylistHistory />
 				<PlaylistPresets />
 				<PlaylistHistory />
 			</div>

--- a/app/playlist-presets/page.tsx
+++ b/app/playlist-presets/page.tsx
@@ -7,7 +7,7 @@ export default function PlaylistPresets() {
 	const playlistPresetsItems: PlaylistPreset[] = dataPlaylistPresets;
 
 	return (
-		<article className="mx-24 grid gap-6">
+		<article className="mx-4 md:mx-24 grid gap-6">
 			<h2 className="text-2xl font-bold pb-2">Playlist Presets</h2>
 			<section className="grid md:grid-cols-3 gap-4">
 				{playlistPresetsItems.map((playlist, index) => (

--- a/features/playlist-selection/errors-message.tsx
+++ b/features/playlist-selection/errors-message.tsx
@@ -10,7 +10,7 @@ const ErrorMessages = () => {
 	if (!errors.length) return null;
 
 	return (
-		<div className="flex flex-col gap-4 w-80">
+		<div className="flex flex-col gap-4">
 			{errors.map((err) => (
 				<Alert key={err.message} variant={err.type} className="pr-11 relative">
 					<AlertCircle className="h-4 w-4" />

--- a/features/playlist-selection/nb-round-input.tsx
+++ b/features/playlist-selection/nb-round-input.tsx
@@ -21,7 +21,7 @@ const NbRoundInput = () => {
 	};
 
 	return (
-		<Card className="bg-muted/50 w-80">
+		<Card className="bg-muted/50">
 			<CardHeader>
 				<label htmlFor="nb-round" className="text-2xl font-bold pb-2">
 					Number of round

--- a/features/playlist-selection/playlist-history.tsx
+++ b/features/playlist-selection/playlist-history.tsx
@@ -31,7 +31,7 @@ const PlaylistHistory = () => {
 	}
 
 	return (
-		<Card className="w-80 bg-muted/50">
+		<Card className="bg-muted/50">
 			<CardHeader>
 				<h2 className="text-2xl font-bold pb-2">History</h2>
 			</CardHeader>

--- a/features/playlist-selection/playlist-input.tsx
+++ b/features/playlist-selection/playlist-input.tsx
@@ -63,7 +63,7 @@ const PlaylistInput = () => {
 	};
 
 	return (
-		<article className={"grid w-80"}>
+		<article className={"grid"}>
 			<Card className="grid gap-2 bg-muted/50">
 				<CardHeader>
 					<h2 className="text-2xl font-bold pb-2">Custom Playlist</h2>
@@ -96,7 +96,7 @@ const PlaylistInput = () => {
 
 					<Input onChange={(e) => setInput(e.target.value)} />
 				</CardContent>
-				<CardFooter>
+				<CardFooter className="mt-2">
 					<Button className="w-full" onClick={handleStart}>
 						Start the game
 					</Button>

--- a/features/playlist-selection/playlist-presets.tsx
+++ b/features/playlist-selection/playlist-presets.tsx
@@ -10,7 +10,7 @@ const PlaylistPresets = () => {
 	const playlistPresets: PlaylistPreset[] = dataPlaylistPresets.slice(0, 4);
 
 	return (
-		<Card className="w-80 bg-muted/50">
+		<Card className="bg-muted/50">
 			<CardHeader>
 				<h2 className="text-2xl font-bold pb-2">Playlist Presets</h2>
 			</CardHeader>


### PR DESCRIPTION
This pull request includes several changes to improve the layout and responsiveness of the application by adjusting various CSS classes. The most important changes include modifications to the `RootLayout`, `Home`, and individual component files to ensure better alignment and spacing on different screen sizes.

Improvements to layout and responsiveness:

* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL22-R22): Updated the `body` class to include `w-screen` and `min-h-screen` for better full-screen handling, and adjusted the `ul` class to `w-full` for full-width navigation. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL22-R22) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL32-R32)
* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L17-R27): Modified padding and width classes for the main grid layout and its children to improve spacing and alignment on different screen sizes.
* [`app/playlist-presets/page.tsx`](diffhunk://#diff-4e976f1c6c27e6352feaea0b7d031c673518ae3c86c66af4ba8500fdc36e9013L10-R10): Adjusted the `article` class to have responsive margins for better presentation on smaller screens.

Component-specific changes:

* [`features/playlist-selection/errors-message.tsx`](diffhunk://#diff-ff5f7d0f046624f4169eb78f649c3198121276fda553bb8c7b2fd9d243c7a55fL13-R13): Removed fixed width from the `ErrorMessages` component to allow flexible width.
* `features/playlist-selection/nb-round-input.tsx`, `features/playlist-selection/playlist-history.tsx`, `features/playlist-selection/playlist-input.tsx`, `features/playlist-selection/playlist-presets.tsx`: Removed fixed width from various components to allow flexible width and added margin-top to the `CardFooter` for better spacing. [[1]](diffhunk://#diff-5a06d37238e88b6734e81e12dfaa8725f45c671c688e2f46864ce427b5515b11L24-R24) [[2]](diffhunk://#diff-f1c16744dfc8bc40301393eac8d8e5aadf9230bf664d215b1c4e78866916da21L34-R34) [[3]](diffhunk://#diff-c914f24b1fee176bb03ad2620a156faa7875cdfdab84231674d5a0c786b60da5L66-R66) [[4]](diffhunk://#diff-c914f24b1fee176bb03ad2620a156faa7875cdfdab84231674d5a0c786b60da5L99-R99) [[5]](diffhunk://#diff-7b34d686d038e2b097a830f3e41b79150c0d9175de2f06b343e135b6b2b17df1L13-R13)